### PR TITLE
Add 'Add to Home Screen' modal for mobile users

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,10 +99,41 @@
           AGT/SGES e IGR/SARI e seus respectivos ACCs.</p>
         <p class="md-typescale-body-medium english">Online transmission of the ATC communication in the IGU/SBFI region,
           being a tri-national area comprising Brazil, Paraguay, and Argentina, also allows for listening to the
+    <!-- Modal Adicionar à Tela Inicial -->
+    <div id="addToHomeModal" class="add-to-home-modal">
+      <div class="add-to-home-content">
+        <img src="sbfi/android-chrome-192x192.png" alt="App Icon" class="add-to-home-icon">
+        <span class="add-to-home-text">Adicione este app à tela inicial do seu celular para acesso rápido!</span>
+        <button class="add-to-home-close" onclick="document.getElementById('addToHomeModal').style.display='none'">×</button>
+      </div>
+    </div>
+    <script>
+      // Exibe o modal após 2 segundos
+      setTimeout(function() {
+        document.getElementById('addToHomeModal').style.display = 'flex';
+      }, 2000);
+    </script>
           communications of AGT/SGES and IGR/SARI airports and their respective ACCs.</p>
       </div>
     </md-elevated-card>
   </main>
+
+  <!-- Modal Adicionar à Tela Inicial -->
+  <div id="addToHomeModal" class="add-to-home-modal" style="display: none;">
+    <div class="add-to-home-content">
+      <div class="add-to-home-icon">
+        <md-icon>phone_android</md-icon>
+      </div>
+      <div class="add-to-home-text">
+        <h3 class="md-typescale-title-medium">Adicionar à tela inicial</h3>
+        <p class="md-typescale-body-medium">Tenha acesso rápido ao ATC direto da sua tela inicial</p>
+      </div>
+      <md-icon-button id="closeAddToHomeModal" class="add-to-home-close">
+        <md-icon>close</md-icon>
+      </md-icon-button>
+    </div>
+  </div>
+
   <footer>
     <p class="md-typescale-body-small copyright">Copyright &copy; by <a
         href="http://iguspotters.com.br/">iguspotters.com.br</a></p>

--- a/sbfi/site.webmanifest
+++ b/sbfi/site.webmanifest
@@ -1,1 +1,23 @@
-{"name":"","short_name":"","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}
+{
+  "name": "IGU/SBFI ATC - Controle de Tráfego Aéreo",
+  "short_name": "SBFI ATC",
+  "description": "Transmissão online da fonia do controle de tráfego aéreo de IGU/SBFI",
+  "icons": [
+    {
+      "src": "/sbfi/android-chrome-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/sbfi/android-chrome-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ],
+  "theme_color": "#1565C0",
+  "background_color": "#F8F9FA",
+  "display": "standalone",
+  "start_url": "/",
+  "scope": "/",
+  "orientation": "portrait"
+}

--- a/script.js
+++ b/script.js
@@ -305,4 +305,74 @@ document.addEventListener('DOMContentLoaded', function() {
                 console.log('Falha ao registrar Service Worker:', error);
             });
     }
+
+    // ========================================
+    // MODAL ADICIONAR À TELA INICIAL
+    // ========================================
+    
+    const addToHomeModal = document.getElementById('addToHomeModal');
+    const closeAddToHomeModal = document.getElementById('closeAddToHomeModal');
+    
+    // Verificar se é um dispositivo móvel
+    function isMobileDevice() {
+        return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+    }
+    
+    // Verificar se já está instalado como PWA
+    function isStandalone() {
+        return window.matchMedia('(display-mode: standalone)').matches || 
+               window.navigator.standalone === true;
+    }
+    
+    // Verificar se o modal já foi mostrado (usando localStorage)
+    function hasSeenAddToHomePrompt() {
+        return localStorage.getItem('addToHomePromptShown') === 'true';
+    }
+    
+    // Marcar como já mostrado
+    function markAddToHomePromptShown() {
+        localStorage.setItem('addToHomePromptShown', 'true');
+    }
+    
+    // Mostrar o modal
+    function showAddToHomeModal() {
+        addToHomeModal.style.display = 'block';
+        // Pequeno delay para a animação funcionar
+        setTimeout(() => {
+            addToHomeModal.classList.add('show');
+        }, 50);
+    }
+    
+    // Esconder o modal
+    function hideAddToHomeModal() {
+        addToHomeModal.classList.remove('show');
+        setTimeout(() => {
+            addToHomeModal.style.display = 'none';
+        }, 300);
+        markAddToHomePromptShown();
+    }
+    
+    // Event listener para fechar o modal
+    closeAddToHomeModal.addEventListener('click', hideAddToHomeModal);
+    
+    // Fechar modal clicando fora do conteúdo
+    addToHomeModal.addEventListener('click', (e) => {
+        if (e.target === addToHomeModal) {
+            hideAddToHomeModal();
+        }
+    });
+    
+    // Mostrar o modal após 3 segundos se atender as condições
+    setTimeout(() => {
+        if (isMobileDevice() && !isStandalone() && !hasSeenAddToHomePrompt()) {
+            showAddToHomeModal();
+        }
+    }, 3000);
+    
+    // Esconder modal ao pressionar ESC
+    document.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape' && addToHomeModal.classList.contains('show')) {
+            hideAddToHomeModal();
+        }
+    });
 });

--- a/styles.css
+++ b/styles.css
@@ -383,5 +383,129 @@ md-icon {
   display: none;
 }
 
+/* ========================================
+   MODAL ADICIONAR À TELA INICIAL
+   ======================================== */
+
+.add-to-home-modal {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 2000;
+  background: linear-gradient(0deg, rgba(0, 0, 0, 0.4) 0%, transparent 100%);
+  padding: 0 16px 16px 16px;
+  transform: translateY(100%);
+  transition: transform 0.3s cubic-bezier(0.4, 0.0, 0.2, 1);
+  pointer-events: none;
+}
+
+.add-to-home-modal.show {
+  transform: translateY(0);
+  pointer-events: all;
+}
+
+.add-to-home-content {
+  background-color: var(--md-sys-color-surface);
+  border-radius: 16px;
+  padding: 20px;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.16);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(8px);
+  position: relative;
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.add-to-home-icon {
+  flex-shrink: 0;
+  width: 48px;
+  height: 48px;
+  background-color: var(--md-sys-color-primary-container);
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.add-to-home-icon md-icon {
+  color: var(--md-sys-color-on-primary-container);
+  font-size: 24px;
+}
+
+.add-to-home-text {
+  flex: 1;
+  text-align: left;
+}
+
+.add-to-home-text h3 {
+  margin: 0 0 4px 0;
+  color: var(--md-sys-color-on-surface);
+  font-weight: 500;
+}
+
+.add-to-home-text p {
+  margin: 0;
+  color: var(--md-sys-color-on-surface-variant);
+  line-height: 1.4;
+}
+
+.add-to-home-close {
+  flex-shrink: 0;
+  --md-icon-button-icon-color: var(--md-sys-color-on-surface-variant);
+}
+
+.add-to-home-close:hover {
+  --md-icon-button-state-layer-color: var(--md-sys-color-on-surface);
+}
+
+/* Animação de entrada suave */
+@keyframes slideUp {
+  from {
+    transform: translateY(100%);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+.add-to-home-modal.animate-in {
+  animation: slideUp 0.3s cubic-bezier(0.4, 0.0, 0.2, 1) forwards;
+}
+
+/* Responsividade para telas menores */
+@media screen and (max-width: 480px) {
+  .add-to-home-modal {
+    padding: 0 12px 12px 12px;
+  }
+  
+  .add-to-home-content {
+    padding: 16px;
+    gap: 12px;
+  }
+  
+  .add-to-home-icon {
+    width: 40px;
+    height: 40px;
+  }
+  
+  .add-to-home-icon md-icon {
+    font-size: 20px;
+  }
+  
+  .add-to-home-text h3 {
+    font-size: 16px;
+  }
+  
+  .add-to-home-text p {
+    font-size: 14px;
+  }
+}
+
 
 


### PR DESCRIPTION
Introduces a modal prompting mobile users to add the app to their home screen for quick access. Includes related HTML, CSS for styling and animation, JavaScript for modal logic and display conditions, and updates the web manifest for improved PWA support.